### PR TITLE
Workaround for bug when using SmartPaginationCollection with psycopg2 backend.

### DIFF
--- a/tgext/crud/utils.py
+++ b/tgext/crud/utils.py
@@ -105,7 +105,14 @@ class SortableTableBase(TableBase):
 class SmartPaginationCollection():
     def __init__(self, data, total):
         self.data = data
-        self.total = total
+
+        # NOTE: This workaround is not needed nor supported in python3
+        # Verify that the total count is an int, because __len__ protocol
+        # only accepts ints in Python2, when using tgext.admin with psycopg2
+        # backend, total is passed as a long.
+        self.total = int(total)
+        if isinstance(self.total, long):
+            raise OverflowError("Exceeded length pagination limit")
 
     def __getitem__(self, item):
         if not isinstance(item, slice):


### PR DESCRIPTION
When using psycopg2 backend SmartPaginationCollection seems to be passed the total number of pages as a long and uses it as is, when asking the length of the collection the total is returned on the **len** function, this violates the **len** protocol which specifies that **len** may only return an int (when called from len()) causing an exception.

This is a problem that has been reported by at least 2 users on the TG mailing list.
