### PR TITLE
Make pagination configuration more intuitive

### DIFF
--- a/tgext/crud/controller.py
+++ b/tgext/crud/controller.py
@@ -77,8 +77,7 @@ class CrudRestController(RestController):
     title = "Turbogears Admin System"
     keep_params = None
     remember_values = []
-    pagination = {'enabled':True,
-                  'items_per_page':7}
+    pagination = {'items_per_page': 7}
     style = Markup('''
 #menu_items {
   padding:0px 12px 0px 2px;
@@ -213,7 +212,7 @@ class CrudRestController(RestController):
         if tg.request.response_type == 'application/json':
             return self.table_filler.get_value(**kw)
 
-        if self.pagination['enabled']:
+        if self.pagination:
             paginator = request.paginators['value_list']
             paginator.paginate_items_per_page = self.pagination['items_per_page']
         else:
@@ -225,7 +224,7 @@ class CrudRestController(RestController):
             kw.pop('limit', None)
             kw.pop('offset', None)
 
-            if self.pagination['enabled'] and isinstance(self.table_filler, RequestLocalTableFiller):
+            if self.pagination and isinstance(self.table_filler, RequestLocalTableFiller):
                 paginator = request.paginators['value_list']
                 page = paginator.paginate_page - 1
                 values = self.table_filler.get_value(offset=page*paginator.paginate_items_per_page,


### PR DESCRIPTION
It's just a small change, but so you can simply write `pagination = False`
instead of having to do `pagination = {'enabled': False}`.
