### PR TITLE
Allow menu_items to be an OrderedDict

### DIFF
--- a/tgext/crud/controller.py
+++ b/tgext/crud/controller.py
@@ -168,7 +168,7 @@ class CrudRestController(RestController):
         return pass_params
 
     def _adapt_menu_items(self, menu_items):
-        adapted_menu_items = {}
+        adapted_menu_items = type(menu_items)()
 
         for link, model in menu_items.iteritems():
             if inspect.isclass(model):


### PR DESCRIPTION
I'd like to explicitly set the order of the menu_items.
This way, menu_items can be an ordinary dict or an OrderedDict
as it's type gets preserved trough the adaption.
