### PR TITLE
Enhance the handling of search fields

### DIFF
--- a/tgext/crud/templates/get_all.html
+++ b/tgext/crud/templates/get_all.html
@@ -32,13 +32,15 @@
       <div id="crud_btn_new">
         <a href='${tg.url("new", params=tmpl_context.kept_params)}' class="add_link">New $model</a>
         <span py:if="value_list" py:content="tmpl_context.paginators.value_list.pager(link=mount_point+'/')"/>
-        <div id="crud_search">
+        <div py:if="search_fields" id="crud_search">
             <form>
                 <select id="crud_search_field" onchange="crud_search_field_changed(this);">
-                    <option value="${headers[0][0]}" selected="selected">${headers[0][1]}</option>
-                    <option py:for="field,name in headers[1:]" value="${field}">${name}</option>
+                  <py:for each="field, name, selected in search_fields" py:choose="selected">
+                    <option py:when="False" value="${field}">${name}</option>
+                    <option py:otherwise="" value="${field}" selected="selected">${name}</option>
+                  </py:for>
                 </select>
-                <input id="crud_search_value" name="${headers[0][0]}" type="text" placeholder="equals"/>
+                <input id="crud_search_value" name="${current_search[0]}" type="text" placeholder="equals / contains" value="${current_search[1]}" />
                 <input type="submit" value="Search"/>
             </form>
         </div>

--- a/tgext/crud/templates/get_all.jinja
+++ b/tgext/crud/templates/get_all.jinja
@@ -38,18 +38,23 @@
         {% if value_list is defined %}
         <span>{{ tmpl_context.paginators.value_list.pager(link=mount_point+'/') }}</span>
         {% endif%}
-        <div id="crud_search">
+        {% if search_fields %}
+          <div id="crud_search">
             <form>
                 <select id="crud_search_field" onchange="crud_search_field_changed(this);">
-                    <option value="{{ headers[0][0] }}" selected="selected">{{ headers[0][1] }}</option>
-                    {% for field,name in headers[1:] %}
-                    <option value="{{ field }}">{{ name }}</option>
+                    {% for field, name, selected in search_fields %}
+                      {% if selected is not False %}
+                        <option value="{{ field }}" selected="selected">{{ name }}</option>
+                      {% else %}
+                        <option value="{{ field }}">{{ name }}</option>
+                      {% endif %}
                     {% endfor %}
                 </select>
-                <input id="crud_search_value" name="{{ headers[0][0] }} " type="text" placeholder="equals"/>
+                <input id="crud_search_value" name="{{ current_search[0] }} " type="text" placeholder="equals / contains" value="{{ current_search[1] }}" />
                 <input type="submit" value="Search"/>
             </form>
-        </div>
+          </div>
+        {% endif %}
       </div>
       <div class="crud_table">
         {{ tmpl_context.widget(value=value_list, action=mount_point+'.json')|safe }}

--- a/tgext/crud/templates/get_all.mak
+++ b/tgext/crud/templates/get_all.mak
@@ -29,18 +29,23 @@ ${parent.meta()}
          % if tmpl_context.paginators:
            <span>${tmpl_context.paginators.value_list.pager(link=mount_point+'/')}</span>
          % endif
-      <div id="crud_search">
+      % if search_fields:
+        <div id="crud_search">
           <form>
               <select id="crud_search_field" onchange="crud_search_field_changed(this);">
-                  <option value="${headers[0][0]}" selected="selected">${headers[0][1]}</option>
-                  % for field,name in headers[1:]:
-                  <option value="${field}">${name}</option>
+                  % for field, name, selected in search_fields:
+                    % if selected is not False:
+                      <option value="${field}" selected="selected">${name}</option>
+                    % else:
+                      <option value="${field}">${name}</option>
+                    % endif
                   % endfor
               </select>
-              <input id="crud_search_value" name="${headers[0][0]}" type="text" placeholder="equals"/>
+              <input id="crud_search_value" name="${current_search[0]}" type="text" placeholder="equals / contains" value="${current_search[1]}" />
               <input type="submit" value="Search"/>
           </form>
-      </div>
+        </div>
+      % endif
     </div>
     <div class="crud_table">
      ${tmpl_context.widget(value=value_list, action=mount_point+'.json', attrs=dict(style="height:200px; border:solid black 3px;")) |n}

--- a/tgext/crud/utils.py
+++ b/tgext/crud/utils.py
@@ -41,11 +41,6 @@ def set_table_filler_getter(filler, name, function):
     meth = new.instancemethod(function, filler, filler.__class__)
     setattr(filler, name, meth)
 
-def get_table_headers(table):
-    return [(field, table.__headers__.get(field, field))
-            for field in table.__fields__
-            if field != '__actions__']
-
 class SortableColumn(Column):
     def __init__(self, name, *args, **kw):
         super(SortableColumn, self).__init__(name, *args, **kw)


### PR DESCRIPTION
- Allow customizing the filter dropdown menu (field name and label)
- Pre-select currently active filter and show filter value

To customize the available search fields, supply a list property on the
CrudRestController which contains tuples of (field, name) or strings
with field = name which will be used for displaying the available
filters. If you specify True, the previous mechanism of automagically
generating the fields from the table headers will be used (default).
If you specify any False value, there will be no search fields displayed
at all.
