### PR TITLE
Correct test for selected

### DIFF
--- a/tgext/crud/templates/get_all.jinja
+++ b/tgext/crud/templates/get_all.jinja
@@ -43,7 +43,7 @@
             <form>
                 <select id="crud_search_field" onchange="crud_search_field_changed(this);">
                     {% for field, name, selected in search_fields %}
-                      {% if selected is not False %}
+                      {% if selected is not sameas false %}
                         <option value="{{ field }}" selected="selected">{{ name }}</option>
                       {% else %}
                         <option value="{{ field }}">{{ name }}</option>


### PR DESCRIPTION
`is not False` throws `jinja2.exceptions.TemplateAssertionError: no test named 'False'`.

See docs for [lower-case `false` literal](http://jinja.pocoo.org/docs/templates/#literals) and [`sameas` test](http://jinja.pocoo.org/docs/templates/#sameas).
