### PR TITLE
Support for custom ProviderTypeSelector

### DIFF
--- a/tests/test_crud_html.py
+++ b/tests/test_crud_html.py
@@ -34,7 +34,7 @@ class TestCrudHTML(CrudTest):
 
         result = self.app.post('/movies/', params={'title':'Movie Test'})
         assert '<form' in result, result
-        assert '(OperationalError)' in result, result
+        assert '(sqlite3.OperationalError)' in result, result
 
     def test_search(self):
         result = self.app.get('/movies/')

--- a/tests/test_rest_json.py
+++ b/tests/test_rest_json.py
@@ -37,7 +37,7 @@ class TestRestJsonEditCreateDelete(CrudTest):
         metadata.drop_all(tables=[Movie.__table__])
 
         result = self.app.post('/movies', params={'title':'Movie Test'}, status=400)
-        assert result.json['message'].startswith('(OperationalError)')
+        assert result.json['message'].startswith('(sqlite3.OperationalError)'), result
 
     def test_put(self):
         result = self.app.post('/movies', params={'title':'Movie Test'})

--- a/tgext/crud/controller.py
+++ b/tgext/crud/controller.py
@@ -94,6 +94,13 @@ class CrudRestController(RestController):
             will provide response content according to the expected one. If you want
             to avoid HTML access to a plain JSON API you can use this option to limit
             valid responses to application/json.
+            
+        **provider_type_selector_type**
+            Use a custom provider type selector class.
+            By default the ``sprox.providerselector.ProviderTypeSelector`` class will
+            be used to instantiate a provider selector that can select the right provider
+            for ming and sqlalchemy. In case you are not using ming or sqlalchemy or you just
+            want to change the default behavior of the provider selector, you can override this.
 
         **resources**
             A list of CSSSource / JSSource that have to be injected inside CRUD
@@ -125,7 +132,6 @@ class CrudRestController(RestController):
             Form that defines how to create a new model.
             By default ``sprox.formbase.AddRecordForm`` is used.
     """
-    __provider_type_selector_type__ = ProviderTypeSelector
     title = "Turbogears Admin System"
     keep_params = None
     remember_values = []
@@ -134,6 +140,7 @@ class CrudRestController(RestController):
     json_dictify = False # True is slower but provides relations
     conditional_update_field = None
     response_type = None
+    provider_type_selector_type = ProviderTypeSelector
     pagination = {'items_per_page': 7}
     resources = ( crud_style,
                   crud_script )
@@ -251,7 +258,7 @@ class CrudRestController(RestController):
 
         self.menu_items = self._adapt_menu_items(menu_items)
         self.helpers = CrudRestControllerHelpers()
-        self.provider = self.__provider_type_selector_type__().get_selector(self.model).get_provider(self.model, hint=session)
+        self.provider = self.provider_type_selector_type().get_selector(self.model).get_provider(self.model, hint=session)
         self.session = session
 
         if self.json_dictify is True:

--- a/tgext/crud/controller.py
+++ b/tgext/crud/controller.py
@@ -125,7 +125,7 @@ class CrudRestController(RestController):
             Form that defines how to create a new model.
             By default ``sprox.formbase.AddRecordForm`` is used.
     """
-
+    __provider_type_selector_type__ = ProviderTypeSelector
     title = "Turbogears Admin System"
     keep_params = None
     remember_values = []
@@ -251,7 +251,7 @@ class CrudRestController(RestController):
 
         self.menu_items = self._adapt_menu_items(menu_items)
         self.helpers = CrudRestControllerHelpers()
-        self.provider = ProviderTypeSelector().get_selector(self.model).get_provider(self.model, hint=session)
+        self.provider = self.__provider_type_selector_type__().get_selector(self.model).get_provider(self.model, hint=session)
         self.session = session
 
         if self.json_dictify is True:


### PR DESCRIPTION
Added support for custom ProviderTypeSelectors. Using standard sprox naming for the `__provider_type_selector_type__` parameter.